### PR TITLE
Unify module and NuGet releases

### DIFF
--- a/Build/Build-Module.ps1
+++ b/Build/Build-Module.ps1
@@ -1,3 +1,18 @@
+param(
+    [ValidateSet('Manifest', 'Documentation', 'Build', 'Publish')]
+    [string] $ConfigurationGateMode = 'Build',
+
+    [bool] $SignModule = $true,
+
+    [string] $ProjectBuildConfigPath = 'Build\project.build.json',
+
+    [string] $PowerShellGalleryApiKeyPath = 'C:\Support\Important\PowerShellGalleryAPI.txt',
+
+    [string] $GitHubApiKeyPath = 'C:\Support\Important\GitHubAPI.txt'
+)
+
+Import-Module PSPublishModule -Force -ErrorAction Stop
+
 Build-Module -ModuleName 'Transferetto' {
     $Manifest = [ordered] @{
         ModuleVersion        = '2.0.X'
@@ -44,16 +59,15 @@ Build-Module -ModuleName 'Transferetto' {
     New-ConfigurationFormat -ApplyTo 'DefaultPSD1', 'OnMergePSD1' -PSD1Style 'Minimal'
 
     New-ConfigurationDocumentation -Enable -PathReadme 'Docs\Readme.md' -Path 'Docs' -SyncExternalHelpToProjectRoot
-    $ImportSelf = if ([string]::IsNullOrWhiteSpace($Env:ImportSelf)) { $true } else { [bool]::Parse($Env:ImportSelf) }
-    New-ConfigurationImportModule -ImportSelf:$ImportSelf -ImportRequiredModules
+    New-ConfigurationImportModule -ImportSelf -ImportRequiredModules
 
     $newConfigurationBuildSplat = @{
         Enable                            = $true
-        SignModule                        = if ([string]::IsNullOrWhiteSpace($Env:SignModule)) { $true } else { [bool]::Parse($Env:SignModule) }
+        SignModule                        = $SignModule
         MergeModuleOnBuild                = $true
         MergeFunctionsFromApprovedModules = $true
         CertificateThumbprint             = '92e95fb58effa6a4a75e77a33cdd6bfe6dd30f1a'
-        NETProjectPath                    = "$PSScriptRoot\..\Sources\Transferetto.PowerShell"
+        NETProjectPath                    = 'Sources\Transferetto.PowerShell\Transferetto.PowerShell.csproj'
         ResolveBinaryConflicts            = $true
         ResolveBinaryConflictsName        = 'Transferetto.PowerShell'
         NETProjectName                    = 'Transferetto.PowerShell'
@@ -75,13 +89,17 @@ Build-Module -ModuleName 'Transferetto' {
         NETSearchClass                    = 'Transferetto.PowerShell.CmdletConnectFtp'
         NETBinaryModuleDocumentation      = $true
         DeleteTargetModuleBeforeBuild     = $true
-        RefreshPSD1Only                   = if ([string]::IsNullOrWhiteSpace($Env:RefreshPSD1Only)) { $true } else { [bool]::Parse($Env:RefreshPSD1Only) }
     }
     New-ConfigurationBuild @newConfigurationBuildSplat
 
-    New-ConfigurationArtefact -Type Unpacked -Enable -Path "$PSScriptRoot\..\Artefacts\Unpacked" -RequiredModulesPath "$PSScriptRoot\..\Artefacts\Unpacked\Modules"
-    New-ConfigurationArtefact -Type Packed -Enable -Path "$PSScriptRoot\..\Artefacts\Packed" -IncludeTagName -ArtefactName "Transferetto-PowerShellModule.<TagModuleVersionWithPreRelease>.zip" -ID 'ToGitHub'
+    New-ConfigurationProjectBuild -Name 'Transferetto' -ConfigPath $ProjectBuildConfigPath -Enabled -BuildBeforeModule -UseAsReleaseVersionSource -ProvideLocalNuGetFeed -PublishNuget
+    New-ConfigurationRelease -StageRoot 'Artefacts\UploadReady' -VersionSource ProjectBuild -PrimaryProject 'Transferetto' -SynchronizeModuleVersion -PublishOrder 'NuGet', 'PowerShellGallery', 'GitHub'
 
-    #New-ConfigurationPublish -Type PowerShellGallery -FilePath 'C:\Support\Important\PowerShellGalleryAPI.txt' -Enabled:$true
-    #New-ConfigurationPublish -Type GitHub -FilePath 'C:\Support\Important\GitHubAPI.txt' -UserName 'EvotecIT' -Enabled:$true -GenerateReleaseNotes -OverwriteTagName '{ModuleName}-v{ModuleVersionWithPreRelease}'
-}
+    New-ConfigurationArtefact -Type Unpacked -Enable -Path 'Artefacts\Unpacked' -ModulesPath 'Artefacts\Unpacked\Modules'
+    New-ConfigurationArtefact -Type Packed -Enable -Path 'Artefacts\Packed' -ModulesPath 'Artefacts\Packed\Modules' -IncludeTagName -ArtefactName 'Transferetto-PowerShellModule.<TagModuleVersionWithPreRelease>.zip' -ID 'ToGitHub'
+
+    New-ConfigurationPublish -Type PowerShellGallery -FilePath $PowerShellGalleryApiKeyPath -Enabled:$false
+    New-ConfigurationPublish -Type GitHub -FilePath $GitHubApiKeyPath -UserName 'EvotecIT' -RepositoryName 'Transferetto' -Enabled:$false -GenerateReleaseNotes -OverwriteTagName '{ModuleName}-v{ModuleVersionWithPreRelease}'
+
+    New-ConfigurationGate -Mode $ConfigurationGateMode
+} -ExitCode

--- a/Build/project.build.json
+++ b/Build/project.build.json
@@ -2,13 +2,14 @@
   "$schema": "https://raw.githubusercontent.com/EvotecIT/PSPublishModule/main/Schemas/project.build.schema.json",
   "RootPath": "..",
   "ExpectedVersionMap": {
-    "Transferetto": "1.0.X",
-    "Transferetto.Core": "1.0.X",
-    "Transferetto.S3": "1.0.X",
-    "Transferetto.AzureBlob": "1.0.X"
+    "Transferetto": "2.0.X",
+    "Transferetto.Core": "2.0.X",
+    "Transferetto.S3": "2.0.X",
+    "Transferetto.AzureBlob": "2.0.X"
   },
   "ExpectedVersionMapAsInclude": true,
   "ExpectedVersionMapUseWildcards": false,
+  "AlignPackageVersions": true,
   "ExcludeProjects": [
     "Transferetto.Cli",
     "Transferetto.PowerShell",
@@ -26,7 +27,7 @@
   "PublishNuget": false,
   "PublishGitHub": false,
   "CreateReleaseZip": true,
-  "CertificateThumbprint": "483292C9E317AA13B07BB7A96AE9D1A5ED9E7703",
+  "CertificateThumbprint": "92E95FB58EFFA6A4A75E77A33CDD6BFE6DD30F1A",
   "CertificateStore": "CurrentUser",
   "TimeStampServer": "http://timestamp.digicert.com",
   "PublishSource": "https://api.nuget.org/v3/index.json",

--- a/Sources/Transferetto.AzureBlob/Transferetto.AzureBlob.csproj
+++ b/Sources/Transferetto.AzureBlob/Transferetto.AzureBlob.csproj
@@ -9,9 +9,9 @@
     <AssemblyName>Transferetto.AzureBlob</AssemblyName>
     <Title>Transferetto Azure Blob Provider</Title>
     <Description>Azure Blob Storage data transfer provider for Transferetto.</Description>
-    <VersionPrefix>1.0.0</VersionPrefix>
-    <AssemblyVersion>1.0.0</AssemblyVersion>
-    <FileVersion>1.0.0</FileVersion>
+    <VersionPrefix>2.0.1</VersionPrefix>
+    <AssemblyVersion>2.0.1</AssemblyVersion>
+    <FileVersion>2.0.1</FileVersion>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <PackageId>Transferetto.AzureBlob</PackageId>
     <PackageProjectUrl>https://github.com/EvotecIT/Transferetto</PackageProjectUrl>

--- a/Sources/Transferetto.Core/Transferetto.Core.csproj
+++ b/Sources/Transferetto.Core/Transferetto.Core.csproj
@@ -9,9 +9,9 @@
     <AssemblyName>Transferetto.Core</AssemblyName>
     <Title>Transferetto Core</Title>
     <Description>Provider-neutral streaming, integrity receipts, and endpoint contracts for Transferetto.</Description>
-    <VersionPrefix>1.0.0</VersionPrefix>
-    <AssemblyVersion>1.0.0</AssemblyVersion>
-    <FileVersion>1.0.0</FileVersion>
+    <VersionPrefix>2.0.1</VersionPrefix>
+    <AssemblyVersion>2.0.1</AssemblyVersion>
+    <FileVersion>2.0.1</FileVersion>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <PackageId>Transferetto.Core</PackageId>
     <PackageProjectUrl>https://github.com/EvotecIT/Transferetto</PackageProjectUrl>

--- a/Sources/Transferetto.S3/Transferetto.S3.csproj
+++ b/Sources/Transferetto.S3/Transferetto.S3.csproj
@@ -9,9 +9,9 @@
     <AssemblyName>Transferetto.S3</AssemblyName>
     <Title>Transferetto S3 Provider</Title>
     <Description>Amazon S3 and S3-compatible object transfer provider for Transferetto.</Description>
-    <VersionPrefix>1.0.0</VersionPrefix>
-    <AssemblyVersion>1.0.0</AssemblyVersion>
-    <FileVersion>1.0.0</FileVersion>
+    <VersionPrefix>2.0.1</VersionPrefix>
+    <AssemblyVersion>2.0.1</AssemblyVersion>
+    <FileVersion>2.0.1</FileVersion>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <PackageId>Transferetto.S3</PackageId>
     <PackageProjectUrl>https://github.com/EvotecIT/Transferetto</PackageProjectUrl>

--- a/Sources/Transferetto/Transferetto.csproj
+++ b/Sources/Transferetto/Transferetto.csproj
@@ -9,9 +9,9 @@
     <AssemblyName>Transferetto</AssemblyName>
     <Title>Transferetto</Title>
     <Description>Reusable FTP, FTPS, SFTP, and SSH library that powers Transferetto PowerShell cmdlets and future CLI tooling.</Description>
-    <VersionPrefix>1.0.0</VersionPrefix>
-    <AssemblyVersion>1.0.0</AssemblyVersion>
-    <FileVersion>1.0.0</FileVersion>
+    <VersionPrefix>2.0.1</VersionPrefix>
+    <AssemblyVersion>2.0.1</AssemblyVersion>
+    <FileVersion>2.0.1</FileVersion>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <PackageId>Transferetto</PackageId>
     <PackageProjectUrl>https://github.com/EvotecIT/Transferetto</PackageProjectUrl>


### PR DESCRIPTION
This unifies Transferetto's PowerShell module and NuGet release process under one PSPublishModule/PowerForge build.

- Builds the module and all four NuGet packages in one coordinated run.
- Aligns Transferetto, Transferetto.Core, Transferetto.S3, and Transferetto.AzureBlob to the highest module/package version on the 2.0.x line.
- Stages one release set and publishes in NuGet, PowerShell Gallery, then GitHub order.
- Uses the newest available PSPublishModule release without a version constraint.
- Updates all package project versions to the resolved 2.0.1 baseline.

A full Build gate produced the module plus four provenance-verified NuGet packages at version 2.0.1. Publishing was not executed.